### PR TITLE
Automatically update PKGBUILD on AUR

### DIFF
--- a/.github/actions/update-pkgbuild-action/Dockerfile
+++ b/.github/actions/update-pkgbuild-action/Dockerfile
@@ -1,0 +1,11 @@
+FROM archlinux:base
+
+RUN pacman-key --init && \
+    pacman-key --populate archlinux && \
+    pacman -Syu --noconfirm && \
+    pacman -S pacman-contrib --noconfirm && \
+    useradd builder -M -s /bin/bash -U
+
+COPY --chmod=755 main.sh /main.sh
+
+ENTRYPOINT [ "/main.sh" ]

--- a/.github/actions/update-pkgbuild-action/action.yml
+++ b/.github/actions/update-pkgbuild-action/action.yml
@@ -1,0 +1,17 @@
+name: 'Update PKGBUILD'
+description: 'Convert tag lile v1.0.0 to pkgver like 1.0.0 and update .SRCINFO'
+inputs:
+  tag:
+    description: 'The tag like v1.0.0'
+    required: true
+  dir:
+    description: 'The directory contains PKGBUILD'
+    required: false
+    default: '.'
+outputs:
+  pkgver:
+    description: 'The converted pkgver'
+
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/.github/actions/update-pkgbuild-action/main.sh
+++ b/.github/actions/update-pkgbuild-action/main.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/bash
+
+# main.sh
+
+if [[ "$INPUT_TAG" =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]
+then
+    echo "Applying tag $INPUT_TAG to PKGBUILD..."
+    pkgver=${INPUT_TAG//v/}
+    if [[ -n "$INPUT_DIR" ]] && [[ ! "$INPUT_DIR" =~ ^\.+$ ]]
+    then
+        cd "$INPUT_DIR" || exit
+    fi
+    echo "Updating pkgver in PKGBUILD..."
+    sed -i "s/pkgver=.*/pkgver=$pkgver/" PKGBUILD
+    echo "Updating checksums in PKGBUILD..."
+    OLDPWD=$PWD
+    mkdir /tmp/makepkg
+    chown -R builder:builder /tmp/makepkg
+    su builder -c "cp -r . /tmp/makepkg"
+    cd /tmp/makepkg || exit
+    su builder -c updpkgsums
+    echo "Updating .SRCINFO..."
+    su builder -c "makepkg --printsrcinfo" > .SRCINFO
+    cd "$OLDPWD" || exit
+    cp /tmp/makepkg/PKGBUILD PKGBUILD
+    cp /tmp/makepkg/.SRCINFO .SRCINFO
+    echo "pkgver=$pkgver" >> "$GITHUB_OUTPUT"
+else
+    echo "Invalid tag $INPUT_TAG"
+    exit 1
+fi

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,8 @@ updates:
       serde:
         patterns:
         - "serde*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,3 +71,35 @@ jobs:
       with:
         name: linux-x86_64
         path: amd64-linux-gnu.tar.gz
+
+  update-aur-pkgbuild:
+    name: 'Update AUR PKGBUILD'
+    runs-on: 'ubuntu-latest'
+    if: github.event_name == 'push' && github.ref_type == 'tag'
+    needs: 'build'
+    steps:
+      - name: 'Setup Git'
+        run: |
+          echo -e "${{ secrets.AUR_PRIVATE_KEY }}" | install -Dm600 /dev/stdin ~/.ssh/id_ed25519
+          chmod 700 ~/.ssh
+          ssh-keyscan aur.archlinux.org >> ~/.ssh/known_hosts
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+      - name: 'Clone AUR repository'
+        run: git clone "ssh://aur@aur.archlinux.org/waylyrics.git"
+      - name: 'Generate pkgver'
+        id: pkgver
+        uses: ./.github/actions/update-pkgbuild-action
+        with:
+          tag: ${{ github.ref_name }}
+          dir: waylyrics
+      - name: 'Show diff'
+        run: git -C waylyrics diff
+      - name: 'Commit'
+        run: |
+          git -C waylyrics add .
+          git -C waylyrics commit -m "Bump version to ${{ steps.pkgver.outputs.pkgver }}"
+      - name: 'Push'
+        run: git -C waylyrics push origin master


### PR DESCRIPTION
Set secrets `AUR_PRIVATE_KEY` to properly private key which has permission to access AUR without password to do update automatically.

Updating will only happen when you pushed a tag and this tag build success.

This update job can only bump pkgver automatically, but cannot do anything more.

We have also noticed that actions in build job is deprecated because of using obsolete `actions/checkout@v3`, so we added configuration to let dependabot update actions monthly.