### PR TITLE
chore: avoid starting with article in summary

### DIFF
--- a/metainfo/io.github.waylyrics.Waylyrics.metainfo.xml
+++ b/metainfo/io.github.waylyrics.Waylyrics.metainfo.xml
@@ -6,7 +6,7 @@
   </replaces>
 
   <name>Waylyrics</name>
-  <summary>A furry way to show desktop lyrics</summary>
+  <summary>Show desktop lyrics in a furry way</summary>
   <launchable type="desktop-id">io.github.waylyrics.Waylyrics.desktop</launchable>
 
   <developer id="io.github.waylyrics">


### PR DESCRIPTION
According to [metainfo quality guidelines](https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/quality-guidelines/#dont-start-with-an-article), we should avoid starting the summary with an article.