### PR TITLE
refactor: inline variable "text"

### DIFF
--- a/src/sync/lyric/scroll.rs
+++ b/src/sync/lyric/scroll.rs
@@ -54,8 +54,7 @@ fn set_lyric_with_mode(
             set_lyric(window, None, "below");
         }
         LyricDisplayMode::PreferTranslation => {
-            let text = translation.or(origin);
-            set_lyric(window, text, "above");
+            set_lyric(window, translation.or(origin), "above");
             set_lyric(window, None, "below");
         }
     }


### PR DESCRIPTION
Inline variable ```text``` to keep consistent with https://github.com/waylyrics/waylyrics/blob/master/src/sync/lyric/scroll.rs#L45