### PR TITLE
chore: support nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 dhat.out.*
 
 *.mo
+
+.envrc
+/.direnv
+/result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,92 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1721727458,
+        "narHash": "sha256-r/xppY958gmZ4oTfLiHN0ZGuQ+RSTijDblVgVLFi1mw=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "3fb418eaf352498f6b6c30592e3beb63df42ef11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 0,
+        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
+        "path": "/nix/store/mln6wr5z539qgldmsm4j1k8k0dm19yvz-source",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1729265718,
+        "narHash": "sha256-4HQI+6LsO3kpWTYuVGIzhJs1cetFcwT7quWCk/6rqeo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ccc0c2126893dd20963580b6478d1a10a4512185",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,55 @@
+{
+  description = "Waylyrics: the furry way to show desktop lyrics.";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.naersk.url = "github:nix-community/naersk";
+
+  outputs = {nixpkgs, flake-utils, naersk, ...}:
+    flake-utils.lib.eachDefaultSystem (system:
+    let pkgs = import nixpkgs {
+          inherit system;
+        };
+        naersk' = pkgs.callPackage naersk {};
+        nativeBuildInputs = with pkgs; [
+          wrapGAppsHook4
+          pkg-config
+        ];
+        buildInputs = with pkgs; [
+          openssl
+          dbus
+        ];
+    in {
+      defaultPackage = naersk'.buildPackage {
+        inherit nativeBuildInputs buildInputs;
+        
+        src = ./.;
+
+        WAYLYRICS_THEME_PRESETS_DIR="${placeholder "out"}/share/waylyrics/themes";
+
+        postInstall = ''
+install -Dm644 ./metainfo/io.github.waylyrics.Waylyrics.gschema.xml -t $out/share/glib-2.0/schemas/
+install -Dm644 ./metainfo/"io.github.waylyrics.Waylyrics.desktop" -t $out/share/applications/
+glib-compile-schemas $out/share/glib-2.0/schemas/
+install -dm755 $out/share/waylyrics/themes
+cp -r ./themes/* $out/share/waylyrics/themes/
+cp -r ./res/icons/* $out/share/icons/
+
+cd locales
+for po in $(find . -type f -name '*.po')
+do
+    mkdir -p $out/share/locale/''${po#/*}
+    msgfmt -o $out/share/locale/''${po%.po}.mo ''${po}
+done
+'';
+      };
+      devShell = pkgs.mkShell {
+        inherit buildInputs;
+        nativeBuildInputs = with pkgs; [
+          rustc
+          cargo
+          rust-analyzer
+        ] ++ nativeBuildInputs;
+      };
+    }
+  );
+}


### PR DESCRIPTION
this should enable develop using nix, for example, start a development environment using `nix develop`, build via `nix build`, enter a shell with installed waylyrics via `nix shell .`, and run waylyrics directly with `nix run .` under the repo directory.