### PR TITLE
fix: alignment of multi-line text in single label

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -90,15 +90,7 @@ pub fn set_lyric_align(window: &Window, align: config::Align) -> Option<()> {
     let labels = get_labels(&vbox)?;
     for label in labels {
         label.set_halign(align.into());
-        match align {
-            config::Align::Start => label.set_justify(gtk::Justification::Left),
-
-            config::Align::Center => label.set_justify(gtk::Justification::Center),
-
-            config::Align::End => label.set_justify(gtk::Justification::Right),
-
-            config::Align::Fill => label.set_justify(gtk::Justification::Fill),
-        }
+        label.set_justify(align.into());
     }
 
     window.imp().lyric_align.set(align);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -90,6 +90,15 @@ pub fn set_lyric_align(window: &Window, align: config::Align) -> Option<()> {
     let labels = get_labels(&vbox)?;
     for label in labels {
         label.set_halign(align.into());
+        match align {
+            config::Align::Start => label.set_justify(gtk::Justification::Left),
+
+            config::Align::Center => label.set_justify(gtk::Justification::Center),
+
+            config::Align::End => label.set_justify(gtk::Justification::Right),
+
+            config::Align::Fill => label.set_justify(gtk::Justification::Fill),
+        }
     }
 
     window.imp().lyric_align.set(align);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -198,6 +198,17 @@ impl From<Align> for gtk::Align {
     }
 }
 
+impl From<Align> for gtk::Justification {
+    fn from(align: Align) -> Self {
+        match align {
+            Align::Start => gtk::Justification::Left,
+            Align::Center => gtk::Justification::Center,
+            Align::End => gtk::Justification::Right,
+            Align::Fill => gtk::Justification::Fill,
+        }
+    }
+}
+
 #[rustfmt::skip]
 fn default_filter_regexies() -> Vec<String> {
     [


### PR DESCRIPTION
Fixes #383

这个修改没有额外新增第三个 label，而是让现有歌词 label 的内部文本对齐方式跟随用户配置。

之前当一个歌词 label 中包含多行文本时，修改歌词对齐方式可能只会改变 label 控件本身的位置，但 label 内部的多行文本仍然保持默认左对齐。

现在通过将 `config::Align` 映射到 `gtk::Justification`，多行歌词在 label 内部也会按照用户选择的方式左对齐、居中、右对齐或两端对齐。

## 测试
```bash
gdbus emit \
  --session \
  --object-path /io/github/waylyrics/Waylyrics \
  --signal io.github.waylyrics.Waylyrics.SetAboveLabel \
  $'さよなら\nGoodbye, until the day we meet again\n再见，直到我们再次相遇的那一天'
```
### 修改前
<img width="790" height="324" alt="Screenshot_20260523_175523" src="https://github.com/user-attachments/assets/084e807b-21db-4163-bfe0-757d7ac584bd" />

### 修改后
<img width="806" height="324" alt="Screenshot_20260523_174716" src="https://github.com/user-attachments/assets/ad61084d-9a72-40a0-b0d5-d16537530658" />

