### PR TITLE
feat(lyric): 增加配置开关，用于在原文空白间隙时隐藏翻译

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -22,6 +22,7 @@ pub fn build_main_window(
     length_toleration_ms: u128,
     show_default_text_on_idle: bool,
     show_lyric_on_pause: bool,
+    respect_empty_line_as_gap: bool,
     #[cfg(feature = "layer-shell")] layer_shell: bool,
     #[cfg(feature = "layer-shell")] layer_shell_anchor: crate::config::LayerShellAnchor,
 ) -> Window {
@@ -31,6 +32,7 @@ pub fn build_main_window(
         length_toleration_ms,
         show_default_text_on_idle,
         show_lyric_on_pause,
+        respect_empty_line_as_gap,
     );
 
     #[cfg(feature = "layer-shell")]

--- a/src/app/window/imp.rs
+++ b/src/app/window/imp.rs
@@ -26,6 +26,7 @@ pub struct Window {
     pub lyric_display_mode: Cell<LyricDisplayMode>,
     pub show_default_text_on_idle: Cell<bool>,
     pub show_lyric_on_pause: Cell<bool>,
+    pub respect_empty_line_as_gap: Cell<bool>,
 
     pub lyric_start: Cell<Option<SystemTime>>,
     pub lyric_offset_ms: Cell<i64>,

--- a/src/app/window/mod.rs
+++ b/src/app/window/mod.rs
@@ -23,6 +23,7 @@ impl Window {
         length_toleration_ms: u128,
         show_default_text_on_idle: bool,
         show_lyric_on_pause: bool,
+        respect_empty_line_as_gap: bool,
     ) -> Self {
         let window: Self = Object::builder().property("application", app).build();
         let imp = window.imp();
@@ -33,6 +34,7 @@ impl Window {
         imp.length_toleration_ms.set(length_toleration_ms);
         imp.show_default_text_on_idle.set(show_default_text_on_idle);
         imp.show_lyric_on_pause.set(show_lyric_on_pause);
+        imp.respect_empty_line_as_gap.set(respect_empty_line_as_gap);
 
         window
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -146,6 +146,14 @@ pub struct Config {
 
     /// Whether to use <name>-dark.css when system is in dark mode
     pub theme_dark_switch: bool,
+
+    /// Whether to treat empty lyric lines as gaps
+    ///
+    /// When enabled, if the original lyric line is empty (i.e., a gap), the corresponding
+    /// translated lyric line will not be displayed. This prevents the translated lyric
+    /// from showing the previous line while the original lyric is displaying a blank gap,
+    /// ensuring that both lyrics maintain a consistent visual rhythm.
+    pub respect_empty_line_as_gap: bool,
 }
 
 /// check [GTK+'s official document](https://docs.gtk.org/gtk4/ctor.ShortcutTrigger.parse_string.html) for trigger format
@@ -205,6 +213,7 @@ impl Default for Config {
             qqmusic: QQMusicConfig::default(),
             color_scheme: ColorScheme::default(),
             theme_dark_switch: false,
+            respect_empty_line_as_gap: false,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ thread_local! {
 }
 pub static LYRIC_PROVIDERS: OnceLock<Vec<&'static dyn LyricProvider>> = OnceLock::new();
 pub static LYRIC_SEARCH_SKIP: AtomicBool = AtomicBool::new(false);
+pub static RESPECT_EMPTY_LINE_AS_GAP: AtomicBool = AtomicBool::new(false);
 
 pub static MAIN_CONTEXT: LazyLock<MainContext> = LazyLock::new(gtk::glib::MainContext::default);
 static TOKIO_RUNTIME: LazyLock<tokio::runtime::Runtime> =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,6 @@ thread_local! {
 }
 pub static LYRIC_PROVIDERS: OnceLock<Vec<&'static dyn LyricProvider>> = OnceLock::new();
 pub static LYRIC_SEARCH_SKIP: AtomicBool = AtomicBool::new(false);
-pub static RESPECT_EMPTY_LINE_AS_GAP: AtomicBool = AtomicBool::new(false);
 
 pub static MAIN_CONTEXT: LazyLock<MainContext> = LazyLock::new(gtk::glib::MainContext::default);
 static TOKIO_RUNTIME: LazyLock<tokio::runtime::Runtime> =

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use waylyrics::sync::lyric::fetch::tricks::EXTRACT_TRANSLATED_LYRIC;
 use waylyrics::utils::{self, acquire_instance_name, gettext, init_dirs, CUSTOM_CONFIG_PATH};
 use waylyrics::{
     EXCLUDED_REGEXES, GTK_DBUS_CONNECTION, LYRIC_PROVIDERS, MAIN_WINDOW, PLAYER_IDENTITY_BLACKLIST,
-    PLAYER_NAME_BLACKLIST, THEME_PATH,
+    PLAYER_NAME_BLACKLIST, RESPECT_EMPTY_LINE_AS_GAP, THEME_PATH,
 };
 
 use waylyrics::sync::*;
@@ -213,9 +213,11 @@ fn build_ui(app: &Application) -> Result<()> {
         qqmusic,
         color_scheme,
         theme_dark_switch,
+        respect_empty_line_as_gap,
     } = config;
 
     LYRIC_SEARCH_SKIP.store(skip_auto_search, Ordering::Release);
+    RESPECT_EMPTY_LINE_AS_GAP.store(respect_empty_line_as_gap, Ordering::Release);
 
     #[cfg(feature = "tray-icon")]
     if show_tray_icon {

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use waylyrics::sync::lyric::fetch::tricks::EXTRACT_TRANSLATED_LYRIC;
 use waylyrics::utils::{self, acquire_instance_name, gettext, init_dirs, CUSTOM_CONFIG_PATH};
 use waylyrics::{
     EXCLUDED_REGEXES, GTK_DBUS_CONNECTION, LYRIC_PROVIDERS, MAIN_WINDOW, PLAYER_IDENTITY_BLACKLIST,
-    PLAYER_NAME_BLACKLIST, RESPECT_EMPTY_LINE_AS_GAP, THEME_PATH,
+    PLAYER_NAME_BLACKLIST, THEME_PATH,
 };
 
 use waylyrics::sync::*;
@@ -217,7 +217,6 @@ fn build_ui(app: &Application) -> Result<()> {
     } = config;
 
     LYRIC_SEARCH_SKIP.store(skip_auto_search, Ordering::Release);
-    RESPECT_EMPTY_LINE_AS_GAP.store(respect_empty_line_as_gap, Ordering::Release);
 
     #[cfg(feature = "tray-icon")]
     if show_tray_icon {
@@ -257,6 +256,7 @@ fn build_ui(app: &Application) -> Result<()> {
         length_toleration_ms,
         show_default_text_on_idle,
         show_lyric_on_pause,
+        respect_empty_line_as_gap,
         #[cfg(feature = "layer-shell")]
         layer_shell,
         #[cfg(feature = "layer-shell")]

--- a/src/sync/lyric/scroll.rs
+++ b/src/sync/lyric/scroll.rs
@@ -1,4 +1,3 @@
-use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use gtk::glib::{self, ControlFlow, Priority, WeakRef};
@@ -6,8 +5,8 @@ use gtk::subclass::prelude::ObjectSubclassIsExt;
 
 use crate::app::{self, get_label};
 use crate::config::LyricDisplayMode;
+use crate::log::*;
 use crate::lyric_providers::{LyricLineOwned, LyricOwned};
-use crate::{log::*, RESPECT_EMPTY_LINE_AS_GAP};
 
 use crate::sync::{LyricState, TrackState, LYRIC, TRACK_PLAYING_STATE};
 use crate::utils::reset_lyric_labels;
@@ -40,12 +39,17 @@ fn set_lyric_with_mode(
     translation: Option<&LyricLineOwned>,
     origin: Option<&LyricLineOwned>,
 ) {
-    let respect_gap = RESPECT_EMPTY_LINE_AS_GAP.load(Ordering::Acquire);
-    let translation = if respect_gap && origin.is_some_and(|it| it.text.trim().is_empty()) {
-        None
-    } else {
-        translation
+    let translation = {
+        let respect_gap = window.imp().respect_empty_line_as_gap.get();
+        let origin_is_empty = origin.is_some_and(|it| it.text.trim().is_empty());
+
+        if respect_gap && origin_is_empty {
+            None
+        } else {
+            translation
+        }
     };
+
     match window.imp().lyric_display_mode.get() {
         LyricDisplayMode::ShowBoth => {
             set_lyric(window, translation.or(origin), "above");

--- a/src/sync/lyric/scroll.rs
+++ b/src/sync/lyric/scroll.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use gtk::glib::{self, ControlFlow, Priority, WeakRef};
@@ -5,8 +6,8 @@ use gtk::subclass::prelude::ObjectSubclassIsExt;
 
 use crate::app::{self, get_label};
 use crate::config::LyricDisplayMode;
-use crate::log::*;
 use crate::lyric_providers::{LyricLineOwned, LyricOwned};
+use crate::{log::*, RESPECT_EMPTY_LINE_AS_GAP};
 
 use crate::sync::{LyricState, TrackState, LYRIC, TRACK_PLAYING_STATE};
 use crate::utils::reset_lyric_labels;
@@ -39,6 +40,12 @@ fn set_lyric_with_mode(
     translation: Option<&LyricLineOwned>,
     origin: Option<&LyricLineOwned>,
 ) {
+    let respect_gap = RESPECT_EMPTY_LINE_AS_GAP.load(Ordering::Acquire);
+    let translation = if respect_gap && origin.is_some_and(|it| it.text.trim().is_empty()) {
+        None
+    } else {
+        translation
+    };
     match window.imp().lyric_display_mode.get() {
         LyricDisplayMode::ShowBoth => {
             set_lyric(window, translation.or(origin), "above");


### PR DESCRIPTION
此前，当原文出现空白间隙（如间奏部分）时，翻译行依然会持续显示，导致视觉不同步。
本次提交引入了一个配置项 `respect_empty_line_as_gap`（默认关闭），让用户可以自定义此行为。

启用后，渲染层会隐藏与空白原文行对应的翻译行。该实现位于渲染层而非修改底层数据，
因此能轻松地应对一句原文对应多句翻译的 1:N 场景，且未来可以支持即时禁用，无需重新拉取歌词。

Fixes #387