### PR TITLE
feat: support skip-taskbar for Windows and X11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,6 +1180,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "gdk4-x11"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d892b4cf5a07e90e1390e93cd792975746c68b59f790a2de9e96ce77211ea9a"
+dependencies = [
+ "gdk4",
+ "gdk4-x11-sys",
+ "gio",
+ "glib",
+ "libc",
+]
+
+[[package]]
+name = "gdk4-x11-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d41f2e28f62378b081288914325d73bddbb6ccbbadb41aa6392afc71d27002"
+dependencies = [
+ "gdk4-sys",
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4321,6 +4346,7 @@ dependencies = [
  "documented",
  "futures-lite",
  "gdk4-win32",
+ "gdk4-x11",
  "gettext-rs",
  "glib-macros",
  "gtk4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,10 @@ mpris = "2.1.0"
 gtk4-layer-shell = { version = "0.8.0", optional = true }
 tracing-journald = { version = "0.3.1", optional = true }
 
+# `skip-taskbar` sets `_NET_WM_STATE_SKIP_TASKBAR`, an X11/EWMH hint
+[target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
+gdk4-x11 = "0.11.0"
+
 [target.'cfg(target_os = "windows")'.dependencies]
 tray-item = { version = "0.10.0", optional = true }
 windows = { version = "0.62.1", features = [

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -7,6 +7,7 @@ use gtk::{Application, Label};
 pub use window::Window;
 
 use crate::app::utils::set_click_pass_through;
+use crate::app::utils::set_skip_taskbar;
 use crate::{config, DEFAULT_TEXT};
 
 const WINDOW_MIN_HEIGHT: i32 = 120;
@@ -24,6 +25,7 @@ pub fn build_main_window(
     show_lyric_on_pause: bool,
     respect_empty_line_as_gap: bool,
     skip_auto_search: bool,
+    skip_taskbar: bool,
     #[cfg(feature = "layer-shell")] layer_shell: bool,
     #[cfg(feature = "layer-shell")] layer_shell_anchor: crate::config::LayerShellAnchor,
 ) -> Window {
@@ -38,7 +40,7 @@ pub fn build_main_window(
     );
 
     #[cfg(feature = "layer-shell")]
-    if layer_shell {
+    if layer_shell || skip_taskbar {
         use gtk4_layer_shell::{is_supported, KeyboardMode, Layer, LayerShell};
 
         if is_supported() {
@@ -48,7 +50,7 @@ pub fn build_main_window(
             // and https://wayland.app/protocols/wlr-layer-shell-unstable-v1#zwlr_layer_surface_v1:enum:keyboard_interactivity
             LayerShell::set_keyboard_mode(&window, KeyboardMode::OnDemand);
             LayerShell::set_layer(&window, Layer::Overlay);
-        } else {
+        } else if layer_shell {
             tracing::warn!("layer-shell was enabled but unsupported by the compositor!");
         }
 
@@ -58,6 +60,15 @@ pub fn build_main_window(
     window.set_size_request(500, WINDOW_MIN_HEIGHT);
     window.set_title(Some(DEFAULT_TEXT));
     window.set_icon_name(Some(crate::APP_ID_FIXED));
+
+    if skip_taskbar {
+        // the hint needs a `GdkSurface` to exist, and it has to be applied
+        // before the window is mapped, otherwise the window manager has
+        // already registered its taskbar entry
+        gtk::prelude::WidgetExt::realize(&window);
+        set_skip_taskbar(&window, true);
+    }
+
     window.present();
 
     let above_label = Label::builder()

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -40,7 +40,7 @@ pub fn build_main_window(
     );
 
     #[cfg(feature = "layer-shell")]
-    if layer_shell || skip_taskbar {
+    if layer_shell {
         use gtk4_layer_shell::{is_supported, KeyboardMode, Layer, LayerShell};
 
         if is_supported() {
@@ -50,7 +50,7 @@ pub fn build_main_window(
             // and https://wayland.app/protocols/wlr-layer-shell-unstable-v1#zwlr_layer_surface_v1:enum:keyboard_interactivity
             LayerShell::set_keyboard_mode(&window, KeyboardMode::OnDemand);
             LayerShell::set_layer(&window, Layer::Overlay);
-        } else if layer_shell {
+        } else {
             tracing::warn!("layer-shell was enabled but unsupported by the compositor!");
         }
 

--- a/src/app/utils.rs
+++ b/src/app/utils.rs
@@ -85,6 +85,93 @@ pub(super) fn set_click_pass_through(window: &window::Window, enabled: bool) {
     }
 }
 
+/// Keep the main window out of the taskbar.
+///
+/// The hint has to be applied after the widget is realized (so a
+/// `GdkSurface` exists) but before the window is presented, otherwise the
+/// window manager has already added its taskbar entry.
+#[cfg(target_os = "windows")]
+pub(super) fn set_skip_taskbar(window: &window::Window, skip: bool) {
+    use std::ffi::c_void;
+
+    fn set_window_skip_taskbar(hwnd: *mut c_void, skip: bool) {
+        use windows::Win32::Foundation::HWND;
+        use windows::Win32::UI::WindowsAndMessaging::{
+            GetWindowLongPtrW, SetWindowLongPtrW, GWL_EXSTYLE,
+        };
+        let hwnd = HWND(hwnd as _);
+
+        // a window carrying `WS_EX_TOOLWINDOW` and no `WS_EX_APPWINDOW`
+        // is left out of the taskbar
+        const WS_EX_TOOLWINDOW: isize = 0x0000_0080;
+        const WS_EX_APPWINDOW: isize = 0x0004_0000;
+        unsafe {
+            let ex_style = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+            let new_style = if skip {
+                (ex_style | WS_EX_TOOLWINDOW) & !WS_EX_APPWINDOW
+            } else {
+                ex_style & !WS_EX_TOOLWINDOW
+            };
+            if new_style != ex_style {
+                SetWindowLongPtrW(hwnd, GWL_EXSTYLE, new_style);
+            }
+        }
+    }
+
+    let Some(surface) = window.surface().and_downcast::<gdk4_win32::Win32Surface>() else {
+        return;
+    };
+
+    let handle = surface.handle().0;
+
+    set_window_skip_taskbar(handle, skip);
+}
+
+/// macOS has neither the EWMH hint nor the win32 extended style.
+#[cfg(target_os = "macos")]
+pub(super) fn set_skip_taskbar(_window: &window::Window, _skip: bool) {}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+pub(super) fn set_skip_taskbar(window: &window::Window, skip: bool) {
+    if !skip {
+        return;
+    }
+
+    let Some(surface) = window.surface() else {
+        tracing::warn!("skip-taskbar: the window has no surface yet");
+        return;
+    };
+
+    if let Some(surface) = surface.downcast_ref::<gdk4_x11::X11Surface>() {
+        // deprecated since GTK 4.18, but still the only way to ask an X11
+        // window manager to keep the window out of the taskbar
+        #[allow(deprecated)]
+        {
+            surface.set_skip_taskbar_hint(true);
+            surface.set_skip_pager_hint(true);
+        }
+        tracing::info!("skip-taskbar: _NET_WM_STATE_SKIP_TASKBAR was set (X11)");
+        return;
+    }
+
+    // Wayland: xdg-shell has no "keep me out of the taskbar" request, the
+    // compositor decides on its own. Only a layer shell surface is exempt.
+    #[cfg(feature = "layer-shell")]
+    {
+        if gtk4_layer_shell::is_supported() {
+            tracing::info!("skip-taskbar: handled by the layer shell surface (Wayland)");
+            return;
+        }
+    }
+
+    tracing::warn!(
+        "skip-taskbar is enabled, but this display server provides no such hint. \
+         On Wayland, build with the `layer-shell` feature and run with \
+         `LD_PRELOAD=/usr/lib/libgtk4-layer-shell.so`, or configure a window \
+         rule in your compositor instead."
+    );
+}
+
 /// set css style for waylyrics
 /// As said in [GTK+ doc], gtk constructs style from the lower priority ones to the upper ones,
 /// We set priority as `STYLE_PROVIDER_PRIORITY + 1` to override user theme

--- a/src/app/utils.rs
+++ b/src/app/utils.rs
@@ -155,20 +155,15 @@ pub(super) fn set_skip_taskbar(window: &window::Window, skip: bool) {
     }
 
     // Wayland: xdg-shell has no "keep me out of the taskbar" request, the
-    // compositor decides on its own. Only a layer shell surface is exempt.
-    #[cfg(feature = "layer-shell")]
-    {
-        if gtk4_layer_shell::is_supported() {
-            tracing::info!("skip-taskbar: handled by the layer shell surface (Wayland)");
-            return;
-        }
-    }
-
+    // compositor decides on its own. Only a layer shell surface is exempt,
+    // and that has to be asked for explicitly through `layer_shell`, because
+    // a layer surface can no longer be moved or resized by the user.
     tracing::warn!(
-        "skip-taskbar is enabled, but this display server provides no such hint. \
-         On Wayland, build with the `layer-shell` feature and run with \
-         `LD_PRELOAD=/usr/lib/libgtk4-layer-shell.so`, or configure a window \
-         rule in your compositor instead."
+        "skip-taskbar is enabled, but Wayland gives a client no way to ask for \
+         this. Either set `layer-shell = true` (needs the `layer-shell` feature \
+         and `LD_PRELOAD=/usr/lib/libgtk4-layer-shell.so`; note that a layer \
+         surface can no longer be dragged or resized), or hide the taskbar \
+         entry with a window rule in your compositor."
     );
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -109,8 +109,10 @@ pub struct Config {
     ///
     /// - Windows: adds `WS_EX_TOOLWINDOW`
     /// - X11: sets `_NET_WM_STATE_SKIP_TASKBAR`
-    /// - Wayland: xdg-shell has no such request, so a layer shell surface
-    ///   is required (see `layer_shell`)
+    /// - Wayland: xdg-shell has no such request. Either make the window a
+    ///   layer shell surface (see `layer_shell`; note that a layer surface
+    ///   can no longer be dragged or resized), or hide the taskbar entry
+    ///   with a window rule in your compositor.
     pub skip_taskbar: bool,
 
     /// whether to make main window a layer shell surface

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -102,6 +102,17 @@ pub struct Config {
     #[cfg(feature = "tray-icon")]
     pub show_tray_icon: bool,
 
+    /// whether to keep the main window out of the taskbar
+    ///
+    /// useful together with `show_tray_icon`, so that only the tray
+    /// icon remains visible.
+    ///
+    /// - Windows: adds `WS_EX_TOOLWINDOW`
+    /// - X11: sets `_NET_WM_STATE_SKIP_TASKBAR`
+    /// - Wayland: xdg-shell has no such request, so a layer shell surface
+    ///   is required (see `layer_shell`)
+    pub skip_taskbar: bool,
+
     /// whether to make main window a layer shell surface
     ///
     /// see https://wayland.app/protocols/wlr-layer-shell-unstable-v1
@@ -202,6 +213,7 @@ impl Default for Config {
             show_lyric_on_pause: true,
             #[cfg(feature = "tray-icon")]
             show_tray_icon: true,
+            skip_taskbar: false,
             #[cfg(feature = "layer-shell")]
             layer_shell: true,
             #[cfg(feature = "layer-shell")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -200,6 +200,7 @@ fn build_ui(app: &Application) -> Result<()> {
         show_lyric_on_pause,
         #[cfg(feature = "tray-icon")]
         show_tray_icon,
+        skip_taskbar,
         #[cfg(feature = "layer-shell")]
         layer_shell,
         #[cfg(feature = "layer-shell")]
@@ -253,6 +254,7 @@ fn build_ui(app: &Application) -> Result<()> {
         show_lyric_on_pause,
         respect_empty_line_as_gap,
         skip_auto_search,
+        skip_taskbar,
         #[cfg(feature = "layer-shell")]
         layer_shell,
         #[cfg(feature = "layer-shell")]


### PR DESCRIPTION
之前 Wayland 会话下主窗口必然占据一个任务栏条目，配置里没有关掉它的开关。

本次提交引入配置项 `skip-taskbar`（默认关闭），只负责「告诉窗口系统别在任务栏里放我」，
按显示服务器分发实现：

| 平台 | 实现 |
| --- | --- |
| Windows | 加 `WS_EX_TOOLWINDOW`、去掉 `WS_EX_APPWINDOW` |
| X11 / XWayland | `_NET_WM_STATE_SKIP_TASKBAR` |
| Wayland | xdg-shell 没有对应请求，客户端做不到：给出一条 warn，指向 `layer-shell` 这条 workaround |

Wayland 那一条**刻意不做隐式回退**。第一版曾让 `skip-taskbar = true` 顺带把窗口变成 layer
shell surface，实机用下来这是个坏设计：layer surface 的位置由 anchor 决定，**用户不能再拖动
或缩放它**，于是「隐藏任务栏」和「窗口可拖动」变成互斥，而且用户即使显式写
`layer-shell = false` 也躲不开这个副作用。

所以现在：`skip-taskbar` 只设 hint，绝不偷偷切换窗口类型。Wayland 用户拿到一条 warn：

```
skip-taskbar is not supported on Wayland, `layer-shell` can be used as a workaround
```

可行的两条路（细节写在配置注释里，不塞进日志）：

- 显式 `layer-shell = true`。代价是失去拖动/缩放 —— 这句写在 `layer-shell` 字段的配置注释上，
  因为用户是在那里做选择的
- 或者用合成器自己的窗口规则（KDE：系统设置 → 窗口管理 → 窗口规则；等价于 `kwinrulesrc`
  里 `skiptaskbar=true` + `skiptaskbarrule=2`）

hint 必须在 `present()` 之前设置：X11 下 WM 是在窗口映射时读 `_NET_WM_STATE` 的，晚了任务栏
条目已经建好。为此设 hint 前先 `realize()` 一次拿到 `GdkSurface`。

Fixes #461

<details>
<summary>测试记录</summary>

环境：CachyOS + KDE Plasma 6 (Wayland)、GTK 4.22、cargo 1.98、KWin 6。

**X11 / XWayland**

```
$ GDK_BACKEND=x11 waylyrics -c a.toml      # skip-taskbar = true
_NET_WM_STATE(ATOM) = _NET_WM_STATE_FOCUSED, _NET_WM_STATE_SKIP_TASKBAR, _NET_WM_STATE_SKIP_PAGER
KWIN_WL|rc=io.github.waylyrics.Waylyrics|cap=Waylyrics|skip=true|normal=true

$ GDK_BACKEND=x11 waylyrics -c b.toml      # skip-taskbar = false（对照）
_NET_WM_STATE(ATOM) = _NET_WM_STATE_FOCUSED
```

**Wayland**（确认不会隐式切换窗口类型）

`skip-taskbar = true` + `layer-shell = false`：

```
窗口: rc=io.github.waylyrics.Waylyrics._426afa98 | movable=true | resizable=true | layer=2
log : skip-taskbar is not supported on Wayland, `layer-shell` can be used as a workaround
```

窗口仍是普通窗口（`movable=true`），没有被换成 layer surface；日志里也不再出现任何
"handled by the layer shell surface" 字样（实测计数 0）。

对照：显式 `layer-shell = true` 时窗口是 layer surface（`movable=false`）且不进任务栏 ——
那是 layer-shell 自身的功劳，与本选项无关。

**回归与规范**

```
$ cargo test --features offline-test
test result: ok. 24 passed; 0 failed

$ cargo fmt --check                                       # 通过
$ cargo clippy                                            # 未引入新 warning
$ cargo build --features "offline-test layer-shell"       # 干净 target 构建通过
$ cargo check --target x86_64-pc-windows-msvc（片段）      # 通过
```

</details>

**未实测的部分**：手边没有 Windows 机器，win32 那条路径只用
`cargo check --target x86_64-pc-windows-msvc` 单独验证了 API 用法，运行时效果没测。

`X11Surface::set_skip_taskbar_hint` 从 GTK 4.18 起标记 deprecated，但目前设 EWMH hint
没有别的途径，所以加了 `#[allow(deprecated)]` 并留了注释说明。

