### PR TITLE
fix(i18n): search locale files from XDG_DATA_HOME

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,18 @@ fn main() -> Result<glib::ExitCode> {
         #[cfg(target_os = "windows")]
         let result = unsafe { textdomain.push("../share").init() };
         #[cfg(not(target_os = "windows"))]
-        let result = unsafe { textdomain.init() };
+        let result = unsafe {
+            // `init()` searches `XDG_DATA_DIRS`, which per the XDG basedir
+            // spec does not include `XDG_DATA_HOME`. `doc/INSTALLATION.md`
+            // tells users to install the catalogs into
+            // `~/.local/share/locale`, so prepend the data dir itself
+            // (`init()` appends `locale/` on its own; user data outranks
+            // system data), otherwise a local install stays English.
+            match directories::BaseDirs::new() {
+                Some(base_dirs) => textdomain.prepend(base_dirs.data_dir()).init(),
+                None => textdomain.init(),
+            }
+        };
 
         result
     };


### PR DESCRIPTION
`doc/INSTALLATION.md` 教用户把 `.mo` 装进 `~/.local/share/locale`，但
`gettextrs::TextDomain::init()` 只在 `XDG_DATA_DIRS` 里搜，而按 XDG basedir 规范
这个变量不含 `XDG_DATA_HOME`。结果是照着文档做本地安装的用户，界面始终是英文；
打包安装（`/usr/share/locale`）和 Flatpak（locale extension）不受影响。

改动只有一处：`init()` 之前 `prepend` 一次 `BaseDirs::data_dir()`
（`directories` 本来就在依赖里），让用户数据目录排到系统路径前面。

`init()` 内部会自己 `path.join("locale")`，所以传的是 data dir 本身而不是 `.../locale`。
`BaseDirs::new()` 在拿不到 HOME 时返回 `None`，此时退回原来的 `init()`，不引入新的失败路径。

Fixes #463

<details>
<summary>验证</summary>

同一份已装好的 `~/.local/share/locale/zh_CN/LC_MESSAGES/waylyrics.mo`，
**不改任何环境变量**（`XDG_DATA_DIRS` 保持系统默认，其中不含 `~/.local/share`）：

修复前（旧二进制）：

```
using system data paths: "/usr/local/share:/usr/share",
ERROR waylyrics: failed to bind textdomain: Translations not found for language zh.
```

修复后：

```
INFO waylyrics: bind to textdomain: Some("zh_CN.UTF-8")
```

`XDG_DATA_DIRS` 全程没动，所以这个差异只可能来自这次改动。

回归与规范：

```
$ cargo test --features offline-test
test result: ok. 24 passed; 0 failed

$ cargo fmt --check      # 通过
```

</details>
